### PR TITLE
fix: npm run build command and support node 4 & 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "browserslist": "^2.1.4",
     "grunt-concurrent": "^2.3.1",
     "grunt-connect": "^0.2.0",
+    "grunt-contrib-imagemin": "^1.0.1",
     "grunt-kss": "^5.0.1",
     "grunt-postcss": "^0.8.0",
     "grunt-sass-tilde-importer": "^1.0.2",
@@ -56,7 +57,7 @@
   },
   "homepage": "https://github.com/comicrelief/pattern-lab#readme",
   "engines": {
-    "node": "4",
+    "node": ">=4",
     "npm": "4"
   },
   "release": {


### PR DESCRIPTION
GP-161
Frost-client is being upgraded to use node 6, so pattern-lab is needed to support both node 4 and 6
While testing `npm run build` did not work till grunt image minification plugin is added