### PR TITLE
Removing UI Select styles from shop

### DIFF
--- a/sass/themes/shop/2018/shop18.scss
+++ b/sass/themes/shop/2018/shop18.scss
@@ -64,7 +64,6 @@
 
 @import "../../../base/components/progress-indicator/progress-indicator";
 
-@import "../../../base/components/selectbox/selectbox";
 @import "../../../base/components/social/social";
 @import "../../../base/components/table/table";
 @import "../../../base/components/tooltips/tooltips";


### PR DESCRIPTION
Fixes #246 

As we're not using UI selectbox, all the associated UI styles aren't required (and are messing with Shop components too)