### PR TITLE
change black to dark purple in CR theme

### DIFF
--- a/sass/themes/cr/2017/components/buttons/_buttons.scss
+++ b/sass/themes/cr/2017/components/buttons/_buttons.scss
@@ -49,7 +49,7 @@
 
 /* button(font_colour, bg_colour) */
 
-.btn--black {
+.btn--dark-purple {
   @include cr_button_types($colour-white, $colour-dark-purple);
 }
 .btn--purple {

--- a/sass/themes/cr/2017/components/buttons/buttons.twig
+++ b/sass/themes/cr/2017/components/buttons/buttons.twig
@@ -1,7 +1,7 @@
 <h3>Primary buttons</h3>
-<p>Buttons have multiple variations that can be used for styling or functional purposes. The are used in conjunction with the base button <b>.btn .btn--black</b> class</p>
-<a class="btn btn--black" href="#">Link with button class</a>
-<button class="btn btn--black">Native button</button>
+<p>Buttons have multiple variations that can be used for styling or functional purposes. The are used in conjunction with the base button <b>.btn .btn--dark-purple</b> class</p>
+<a class="btn btn--dark-purple" href="#">Link with button class</a>
+<button class="btn btn--dark-purple">Native button</button>
 <br>
 <h3 style="margin-top: 30px;">Secondary / Ghost button</h3>
 <p>Used for less important call-to-actions, particularly when primary buttons are feature on the same component/page, or simply as an alternative styling, where applicable. These buttons appear as ghost (hollow) buttons with 4px solid border and text colour matching the colour of the border. This default styling can be applied by using the <b>.btn--white-ghost</b> class. See Variations for more button syling options.</p>

--- a/sass/themes/cr/2017/components/links/_links.scss
+++ b/sass/themes/cr/2017/components/links/_links.scss
@@ -9,7 +9,7 @@
 // Style guide: 10.2
 
 .link {
-  &.link--black {
+  &.link--dark-purple{
     @include link($colour-black, $colour-red);
   }
   &.link--purple {

--- a/sass/themes/cr/2017/components/links/links.twig
+++ b/sass/themes/cr/2017/components/links/links.twig
@@ -1,5 +1,5 @@
 <p>
-	<a class="link link--black" href="#">black link</a> <i>.link-black</i> Look over here, son
+	<a class="link link--dark-purple" href="#">Dark purple link</a> <i>.link-dark-purple</i> Look over here, son
 </p>
 <p>
 	<a class="link link--red" href="#">Red link</a> <i>.link-red</i> Look over here, son
@@ -20,4 +20,4 @@
 	<a class="link link--grey" href="#">Grey link</a> <i>.link--grey</i> Look over here, son
 </p>
 <h3 style="margin-top: 30px;">Inline Link</h3>
-<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus efficitur sem sit amet interdum. Donec aliquam augue <a href="#" class="link link--black inline">inline link</a>, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus efficitur sem sit amet interdum. Donec aliquam augue</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus efficitur sem sit amet interdum. Donec aliquam augue <a href="#" class="link link--dark-purple inline">inline link</a>, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus efficitur sem sit amet interdum. Donec aliquam augue</p>


### PR DESCRIPTION
fixes: #240 
Changing the class names of black buttons and links to dark purple in the CR theme. This is for clarity as we're changing the naming in the ckeditor from black to dark purple. 
See issue for the config change in comicrelief:
https://github.com/comicrelief/comicrelief/issues/343
