### PR TITLE
fix: reduced padding card when no bg colour

### DIFF
--- a/sass/base/components/card-block/_card.scss
+++ b/sass/base/components/card-block/_card.scss
@@ -30,7 +30,7 @@
 .card__content-wrapper {
   position: relative;
   height: 100%;
-  padding: 30px;
+  padding: 15px;
   @include breakpoint($screen-md-only) {
     @include span(7 wider);
     position: absolute;
@@ -48,6 +48,9 @@
         transform: translateY(0);
       }
     }
+  }
+  &[class*="bg--"]{
+    padding: 30px;
   }
   .cards--feature-layout & {
     z-index: 10;


### PR DESCRIPTION
fixes: #242 

- cards with bg colour should have a padding of 30px
- cards without a bg colour should have a padding of 15px