### PR TITLE
fix: promo header height sr18

### DIFF
--- a/sass/themes/sr/2018/components/promo-header/_promo-header.scss
+++ b/sass/themes/sr/2018/components/promo-header/_promo-header.scss
@@ -1,0 +1,6 @@
+.promo-header {
+  @include breakpoint($screen-md-max) {
+    min-height: 500px;
+  }
+}
+

--- a/sass/themes/sr/2018/sr18.scss
+++ b/sass/themes/sr/2018/sr18.scss
@@ -38,7 +38,7 @@
 @import "components/navigation/_main-nav.scss";
 @import "components/buttons/_buttons.scss";
 @import "components/single-msg/_single-msg.scss";
-
+@import "components/promo-header/_promo-header.scss";
 
 // Header
 //


### PR DESCRIPTION
fixes: #318 

- change promo header height from 600px to 500px in the sr18 theme. (small version remains 400px high)