### PR TITLE
fix: padding card component when no bg colour

### DIFF
--- a/sass/base/components/card-block/_card.scss
+++ b/sass/base/components/card-block/_card.scss
@@ -2,6 +2,9 @@
 //
 // Standard Card Block
 //
+// When no card background colour is selected the card content will have no left and right padding.
+// When a background colour is selected the card content will have padding all around (see cards grid below).
+//
 // Markup: card.twig
 //
 // Style guide: 20.60
@@ -30,7 +33,7 @@
 .card__content-wrapper {
   position: relative;
   height: 100%;
-  padding: 15px;
+  padding: 30px 0;
   @include breakpoint($screen-md-only) {
     @include span(7 wider);
     position: absolute;

--- a/sass/base/components/card-block/card.json
+++ b/sass/base/components/card-block/card.json
@@ -1,5 +1,5 @@
 {
-	"bg_colour": "bg--yellow",
+	"bg_colour": "none",
 	"field_cr_card_image": "kss-assets/images/1-1-img.jpg",
 	"field_cr_card_body": "<h4 class='font--royal-blue text-align-center'>Follow in Dermont's footsteps</h4><p class='text-align-center'>If Dermot's hip-swivelling heroics have inspired you, why not do your bit for Red Nose Day and put on your own dance event?</p><p class='text-align-center'><a class='link link--inline-red' href='#'>Get your Dancing Kit</a></p>"
 }

--- a/sass/base/components/card-block/card.twig
+++ b/sass/base/components/card-block/card.twig
@@ -1,4 +1,4 @@
-<div class="card {{ bg_colour }}">
+<div class="card">
 	{{ title_suffix.contextual_links }}
 	{# {% if field_cr_card_image['#items'].value %} #}
 	<div class="card__image">


### PR DESCRIPTION
fixes: #320 

- change padding when no bg colour to have no padding left and right and keep 30px on top and bottom.
- update card component description to include example of no bg colour
