### PR TITLE
fix: sr18 inline link underlining

### DIFF
--- a/sass/themes/sr/2018/components/links/_links.scss
+++ b/sass/themes/sr/2018/components/links/_links.scss
@@ -27,8 +27,8 @@
     @include link_colour($colour-dark-blue);
   }
   &.inline {
-    display: inline-block;
-    padding-bottom: 0;
+    // display: inline-block;
+    padding-bottom: 0.06em;
     font-family: inherit;
     font-size:inherit;
   }

--- a/sass/themes/sr/2018/components/links/_links.scss
+++ b/sass/themes/sr/2018/components/links/_links.scss
@@ -27,7 +27,7 @@
     @include link_colour($colour-dark-blue);
   }
   &.inline {
-    // display: inline-block;
+    display: inline;
     padding-bottom: 0.06em;
     font-family: inherit;
     font-size:inherit;


### PR DESCRIPTION
fixes: #348 

- Remove `display: inline-block` from inline links and give it `padding-bottom: 0.06em`