### PR TITLE
fix: Centering search icon for svgmask fallback

### DIFF
--- a/sass/themes/sr/2018/components/search/_search-block.scss
+++ b/sass/themes/sr/2018/components/search/_search-block.scss
@@ -104,7 +104,7 @@
       outline: 5px auto -webkit-focus-ring-color;
     }
     .no-cssmask & {
-      background: transparent url($image-path + "search_page_icon.png") center right no-repeat;
+      background: transparent url($image-path + "search_page_icon.png") center no-repeat;
       background-size: 23px;
       @include breakpoint($screen-md) {
         background-size: 25px;


### PR DESCRIPTION
Fixes #415 