### PR TITLE
fix: payin labels for keep in touch row

### DIFF
--- a/sass/themes/payin/sportrelief/components/form/_form.scss
+++ b/sass/themes/payin/sportrelief/components/form/_form.scss
@@ -124,8 +124,10 @@ select {
   .form__subcopy--privacy-policy {
     font-size: 16px;
   }
-  .form__subcopy {
-    margin-bottom: 0;
+  
+  .form__subcopy--certificate,
+  .form__subcopy--contact {
+    font-weight: bold;
   }
 }
 

--- a/sass/themes/payin/sportrelief/components/form/_form.scss
+++ b/sass/themes/payin/sportrelief/components/form/_form.scss
@@ -127,6 +127,7 @@ select {
   
   .form__subcopy--certificate,
   .form__subcopy--contact {
+    @extend p;
     font-weight: bold;
   }
 }

--- a/sass/themes/payin/sportrelief/pages/payin-page.twig
+++ b/sass/themes/payin/sportrelief/pages/payin-page.twig
@@ -423,30 +423,36 @@
           </div>
         </div>
         <div class="form__row form__row--keep-touch">
-        <div class="form__fieldset">
-          <p class="form__subcopy form__subcopy--certificate">Certificate</p>
-          <div class="form__field--wrapper form__checkbox form__field--certificate">
-            <label class="form__checkbox" for="comicrelief_payin_general_certificate">I would like to request a fundraising certificate</label>
-            <input type="checkbox" id="comicrelief_payin_general_certificate" name="comicrelief_payin_general[certificate]" value="1">
-            <span></span>       
+          <div class="form__fieldset">
+            <fieldset>
+              <legend class="form__subcopy form__subcopy--certificate">Certificate</legend>
+              <div class="form__field--wrapper form__checkbox form__field--certificate">
+                <label class="form__checkbox" for="comicrelief_payin_general_certificate">I would like to request a fundraising certificate</label>
+                <input type="checkbox" id="comicrelief_payin_general_certificate" name="comicrelief_payin_general[certificate]" value="1">
+                <span></span>
+              </div>
+            </fieldset>
+            <fieldset>
+              <legend class="form__subcopy form__subcopy--contact">Contact preferences</legend>
+              <p class="form__subcopy">We’d love to send you some great fundraising tips &amp; tools, campaign news and keep you in the loop with how you can support and give donations to Comic Relief.</p>
+              <div class="form__field--wrapper form__checkbox form__field--permissionEmail">
+                <label class="form__checkbox" for="comicrelief_payin_general_permissionEmail">I'm happy to hear from Comic Relief by email.</label>
+                <input type="checkbox" id="comicrelief_payin_general_permissionEmail" name="comicrelief_payin_general[permissionEmail]" value="1">
+                <span></span> 
+              </div>
+            </fieldset>
+            <fieldset>
+              <p class="form__subcopy form__subcopy--permissionPost">
+                Comic Relief may send you marketing and fundraising materials by post and process your personal information for our legitimate business interests.</p>
+              <div class="form__field--wrapper form__checkbox form__field--permissionPost">
+                <label class="form__checkbox" for="comicrelief_payin_general_permissionPost">I do not wish to receive any postal marketing</label>
+                <input type="checkbox" id="comicrelief_payin_general_permissionPost" name="comicrelief_payin_general[permissionPost]" value="1">
+                <span></span> 
+              </div>
+            </fieldset>
+              <p class="form__subcopy form__subcopy--privacy-policy">
+                We will never share or sell your details with anyone for marketing purposes. Read our <a href="https://www.sportrelief.com/privacy-policy" target="blank">privacy policy</a> to see how we look after your information.</p>
           </div>
-          <p class="form__subcopy form__subcopy--contact">Contact preferences</p>
-          <p class="form__subcopy">We’d love to send you some great fundraising tips &amp; tools, campaign news and keep you in the loop with how you can support and give donations to Comic Relief.</p>
-          <div class="form__field--wrapper form__checkbox form__field--permissionEmail">
-            <label class="form__checkbox" for="comicrelief_payin_general_permissionEmail">I'm happy to hear from Comic Relief by email.</label>
-            <input type="checkbox" id="comicrelief_payin_general_permissionEmail" name="comicrelief_payin_general[permissionEmail]" value="1">
-            <span></span>    
-          </div>
-          <p class="form__subcopy form__subcopy--permissionPost">
-            Comic Relief may send you marketing and fundraising materials by post and process your personal information for our legitimate business interests.</p>
-          <div class="form__field--wrapper form__checkbox form__field--permissionPost">
-            <label class="form__checkbox" for="comicrelief_payin_general_permissionPost">I do not wish to receive any postal marketing</label>
-            <input type="checkbox" id="comicrelief_payin_general_permissionPost" name="comicrelief_payin_general[permissionPost]" value="1">
-            <span></span> 
-          </div>
-          <p class="form__subcopy form__subcopy--privacy-policy">
-            We will never share or sell your details with anyone for marketing purposes. Read our <a href="https://www.sportrelief.com/privacy-policy" target="blank">privacy policy</a> to see how we look after your information.</p>
-          </div>  
         </div>
         <div class="form__row form__nav">
           <div class="form__fieldset">

--- a/sass/themes/payin/sportrelief/pages/payin-page.twig
+++ b/sass/themes/payin/sportrelief/pages/payin-page.twig
@@ -423,23 +423,30 @@
           </div>
         </div>
         <div class="form__row form__row--keep-touch">
-          <div class="form__fieldset">
-            <p class="form__subcopy">Certificate</p>
-            <div class="form__field--wrapper form__checkbox form__field--permissionPost">
-              <label class="form__field form__field--permissionPost form__checkbox" for="comicrelief_payin_general_permissionPost">I would like to request a fundraising certificate</label><input type="checkbox" id="comicrelief_payin_general_permissionPost" name="comicrelief_payin_general[permissionPost]" class="form__field form__field--permissionPost" value="1" checked="checked">
-              <span></span>
-              <div class="form__field--error"></div>
-            </div>
-            <p class="form__subcopy">Our emails</p>
-            <div class="form__field--wrapper form__checkbox form__field--permissionEmail">
-              <label class="form__field form__field--permissionEmail form__checkbox" for="comicrelief_payin_general_permissionEmail">To receive fundraising tips, tools, campaign news by email, and be kept in the loop with how you can support and give donations to Comic Relief, please tick this box. Even if you’re already signed-up, please tick the box to continue to get emails from us.
-              </label><input type="checkbox" id="comicrelief_payin_general_permissionEmail" name="comicrelief_payin_general[permissionEmail]" class="form__field form__field--permissionEmail" value="1">
-              <span></span>
-              <div class="form__field--error"></div>
-            </div>
-            <p class="form__subcopy form__subcopy--privacy-policy">
-              Comic Relief may send you marketing and fundraising materials by post and process your personal information for our legitimate business interests. If you do not want to receive anything by post please contact us or simply tick the box included on all our materials and return to us. We will never share or sell your details with anyone for marketing purposes. Read our <a href="https://www.sportrelief.com/privacy-policy" target="blank">privacy policy</a> to see how we look after your information.</p>
+        <div class="form__fieldset">
+          <p class="form__subcopy form__subcopy--certificate">Certificate</p>
+          <div class="form__field--wrapper form__checkbox form__field--certificate">
+            <label class="form__checkbox" for="comicrelief_payin_general_certificate">I would like to request a fundraising certificate</label>
+            <input type="checkbox" id="comicrelief_payin_general_certificate" name="comicrelief_payin_general[certificate]" value="1">
+            <span></span>       
           </div>
+          <p class="form__subcopy form__subcopy--contact">Contact preferences</p>
+          <p class="form__subcopy">We’d love to send you some great fundraising tips &amp; tools, campaign news and keep you in the loop with how you can support and give donations to Comic Relief.</p>
+          <div class="form__field--wrapper form__checkbox form__field--permissionEmail">
+            <label class="form__checkbox" for="comicrelief_payin_general_permissionEmail">I'm happy to hear from Comic Relief by email.</label>
+            <input type="checkbox" id="comicrelief_payin_general_permissionEmail" name="comicrelief_payin_general[permissionEmail]" value="1">
+            <span></span>    
+          </div>
+          <p class="form__subcopy form__subcopy--permissionPost">
+            Comic Relief may send you marketing and fundraising materials by post and process your personal information for our legitimate business interests.</p>
+          <div class="form__field--wrapper form__checkbox form__field--permissionPost">
+            <label class="form__checkbox" for="comicrelief_payin_general_permissionPost">I do not wish to receive any postal marketing</label>
+            <input type="checkbox" id="comicrelief_payin_general_permissionPost" name="comicrelief_payin_general[permissionPost]" value="1">
+            <span></span> 
+          </div>
+          <p class="form__subcopy form__subcopy--privacy-policy">
+            We will never share or sell your details with anyone for marketing purposes. Read our <a href="https://www.sportrelief.com/privacy-policy" target="blank">privacy policy</a> to see how we look after your information.</p>
+          </div>  
         </div>
         <div class="form__row form__nav">
           <div class="form__fieldset">
@@ -860,19 +867,30 @@
           </div>
         </div>
         <div class="form__row form__row--keep-touch">
-          <div class="form__fieldset">
-            <h4 class="form__subtitle">Stay up to date</h4>
-            <p class="form__subcopy">We'd love to keep you in the loop with what Comic Relief is up to and how your fundraising money is helping change lives for the better. It's the least we can do for your incredible support.</p>
-            <p class="form__subcopy">Your details will be kept safe and never given to other organisations. This applies to the e-mail and address entered above. See our <a href="https://www.rednoseday.com/legal#privacy" target="blank">privacy policy</a>.</p>
-            <div class="form__field--wrapper form__checkbox form__field--permissionEmail">
-              <label class="form__field form__field--permissionEmail form__checkbox" for="comicrelief_payin_school_permissionEmail">I'm happy to hear from Comic Relief by email.</label><input type="checkbox" id="comicrelief_payin_school_permissionEmail" name="comicrelief_payin_school[permissionEmail]" class="form__field form__field--permissionEmail" value="1">
-              <div class="form__field--error"></div>
-            </div>
-            <div class="form__field--wrapper form__checkbox form__field--permissionPost">
-              <label class="form__field form__field--permissionPost form__checkbox" for="comicrelief_payin_school_permissionPost">I'm happy to receive items by post a couple of times a year (like a free Fundraising kit).</label><input type="checkbox" id="comicrelief_payin_school_permissionPost" name="comicrelief_payin_school[permissionPost]" class="form__field form__field--permissionPost" value="1" checked="checked">
-              <div class="form__field--error"></div>
-            </div>
+        <div class="form__fieldset">
+          <p class="form__subcopy form__subcopy--certificate">Certificate</p>
+          <div class="form__field--wrapper form__checkbox form__field--certificate">
+            <label class="form__checkbox" for="comicrelief_payin_general_certificate">I would like to request a fundraising certificate</label>
+            <input type="checkbox" id="comicrelief_payin_general_certificate" name="comicrelief_payin_general[certificate]" value="1">
+            <span></span> 
           </div>
+          <p class="form__subcopy form__subcopy--contact">Contact preferences</p>
+          <p class="form__subcopy">We’d love to send you some great fundraising tips &amp; tools, campaign news and keep you in the loop with how you can support and give donations to Comic Relief.</p>
+          <div class="form__field--wrapper form__checkbox form__field--permissionEmail">
+            <label class="form__checkbox" for="comicrelief_payin_general_permissionEmail">I'm happy to hear from Comic Relief by email.</label>
+            <input type="checkbox" id="comicrelief_payin_general_permissionEmail" name="comicrelief_payin_general[permissionEmail]" value="1">
+            <span></span>
+          </div>
+          <p class="form__subcopy form__subcopy--permissionPost">
+            Comic Relief may send you marketing and fundraising materials by post and process your personal information for our legitimate business interests.</p>
+          <div class="form__field--wrapper form__checkbox form__field--permissionPost">
+            <label class="form__checkbox" for="comicrelief_payin_general_permissionPost">I do not wish to receive any postal marketing</label>
+            <input type="checkbox" id="comicrelief_payin_general_permissionPost" name="comicrelief_payin_general[permissionPost]" value="1">
+            <span></span>
+          </div>
+          <p class="form__subcopy form__subcopy--privacy-policy">
+            We will never share or sell your details with anyone for marketing purposes. Read our <a href="https://www.sportrelief.com/privacy-policy" target="blank">privacy policy</a> to see how we look after your information.</p>
+          </div>  
         </div>
         <div class="form__row form__nav">
           <div class="form__fieldset">


### PR DESCRIPTION
fixes #501 

- update the twig file with markup from payin
- change "Certificate" and "Contact preferences" to bold