### PR TITLE
fix: base - remove logo from press release article

### DIFF
--- a/sass/base/components/news-article/_press-release-article.scss
+++ b/sass/base/components/news-article/_press-release-article.scss
@@ -9,23 +9,6 @@
 		text-align: left;
 		width: 100%;
 		position: relative;
-		&:before {
-			background: url($image-path + "press-logos.png") no-repeat 0 0;
-			background-size: 70px;
-			content: " ";
-			display: block;
-			width: 70px;
-			height: 70px;
-			position: absolute;
-			left: 30px;
-			top: 10px;
-			.page-node-type-article-press-release--comicrelief & {
-				background-position: 0 -77px;
-			}
-			.page-node-type-article-press-release--sportrelief & {
-				background-position: 0 -157px;
-			}
-		}
 	}
 	.cr-article__social-links {
 		display: none;


### PR DESCRIPTION
fixes: #540 
relates to: https://github.com/comicrelief/comicrelief/issues/479

The logos of the press release teaser shouldn't be affected.

can be previewed here: 
teaser: http://pr-480-hzvnw4i-3g6y4v7pqt6nk.eu.platform.sh/press-releases 
press-release article: http://pr-480-hzvnw4i-3g6y4v7pqt6nk.eu.platform.sh/press-releases/hes-againgreg-james-kicks-bbc-radio-1s-gregathlon-pedal-peaks-sport-relief
