### PR TITLE
fix: Update package.json's minimum Node version to 8 too

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "homepage": "https://github.com/comicrelief/pattern-lab#readme",
   "engines": {
-    "node": ">=6",
+    "node": ">=8",
     "npm": ">=4"
   },
   "release": {


### PR DESCRIPTION
Should reduce dev confusion if it now needs this version to work