### PR TITLE
remove overriding bold styles - donate card theme

### DIFF
--- a/sass/themes/donate/donate-cr/components/cards/_cards.scss
+++ b/sass/themes/donate/donate-cr/components/cards/_cards.scss
@@ -32,7 +32,6 @@
 
       a {
         color: $colour-dark-purple;
-        font-family:$font-regular;
       }
     }
   }


### PR DESCRIPTION
fix: overriding bold styles - donate card theme