### PR TITLE
fix: donate-cr - removing promo header

### DIFF
--- a/sass/themes/donate/donate-cr/donate-cr.scss
+++ b/sass/themes/donate/donate-cr/donate-cr.scss
@@ -70,7 +70,6 @@
 // ==========================================================================
 @import "components/form/_form.scss";
 @import "components/header/_header.scss";
-@import "components/promo-header/_promo-header.scss";
 @import "components/partner-footer/_partner-footer.scss";
 @import "components/cards/_cards.scss";
 @import "components/buttons/_buttons.scss";


### PR DESCRIPTION
fixes: #655 
removing promo header for cr donate as it's overridden per cart in the donate environment