### PR TITLE
Fix: set height properly on CW teaser blocks

### DIFF
--- a/sass/themes/sr/2018/components/teaser-block/_teaser-block.scss
+++ b/sass/themes/sr/2018/components/teaser-block/_teaser-block.scss
@@ -30,7 +30,7 @@
 
     /* Ensure the last element is flush to the padding of the block */
     .cr-body {
-      height: 100%;
+      height: auto;
       
       > *:last-child {
         margin-bottom: 0;


### PR DESCRIPTION
Fixes #913 